### PR TITLE
do an actual pattern analysis to infer its deps

### DIFF
--- a/internal/phpgrep/format.go
+++ b/internal/phpgrep/format.go
@@ -1,0 +1,94 @@
+package phpgrep
+
+import (
+	"text/template/parse"
+)
+
+type formatDeps struct {
+	capture bool
+}
+
+func inspectFormatDeps(format string) formatDeps {
+	var deps formatDeps
+
+	treeMap, err := parse.Parse("output-format", format, "", "", nil)
+	if err != nil {
+		return deps
+	}
+	tree, ok := treeMap["output-format"]
+	if !ok {
+		return deps
+	}
+
+	walkTemplate(tree.Root, func(n parse.Node) bool {
+		switch n := n.(type) {
+		case *parse.FieldNode:
+			if len(n.Ident) != 1 {
+				break
+			}
+			switch n.Ident[0] {
+			case "Filename", "Line", "Match":
+				// No need to track these.
+			default:
+				deps.capture = true
+			}
+		}
+		return true
+	})
+
+	return deps
+}
+
+func walkTemplate(n parse.Node, visit func(parse.Node) bool) {
+	if n == nil {
+		return
+	}
+	if !visit(n) {
+		return
+	}
+
+	switch n := n.(type) {
+	case *parse.ListNode:
+		walkTemplateSlice(n.Nodes, visit)
+
+	case *parse.PipeNode:
+		for i := range n.Decl {
+			walkTemplate(n.Decl[i], visit)
+		}
+		for i := range n.Cmds {
+			walkTemplate(n.Cmds[i], visit)
+		}
+
+	case *parse.ActionNode:
+		walkTemplate(n.Pipe, visit)
+
+	case *parse.CommandNode:
+		walkTemplateSlice(n.Args, visit)
+
+	case *parse.ChainNode:
+		walkTemplate(n.Node, visit)
+
+	case *parse.IfNode:
+		walkTemplateBranch(n.BranchNode, visit)
+
+	case *parse.RangeNode:
+		walkTemplateBranch(n.BranchNode, visit)
+
+	case *parse.TemplateNode:
+		walkTemplate(n.Pipe, visit)
+	}
+}
+
+func walkTemplateBranch(n parse.BranchNode, visit func(parse.Node) bool) {
+	walkTemplate(n.Pipe, visit)
+	walkTemplate(n.List, visit)
+	if n.ElseList != nil {
+		walkTemplate(n.ElseList, visit)
+	}
+}
+
+func walkTemplateSlice(nodes []parse.Node, visit func(parse.Node) bool) {
+	for _, n := range nodes {
+		walkTemplate(n, visit)
+	}
+}

--- a/internal/phpgrep/format_test.go
+++ b/internal/phpgrep/format_test.go
@@ -1,0 +1,49 @@
+package phpgrep
+
+import (
+	"testing"
+)
+
+func TestInspectFormatDeps(t *testing.T) {
+	tests := []struct {
+		format string
+		deps   formatDeps
+	}{
+		{
+			format: ``,
+			deps:   formatDeps{},
+		},
+
+		{
+			format: defaultFormat,
+			deps:   formatDeps{},
+		},
+		{
+			format: `{{.Filename}}: blah`,
+			deps:   formatDeps{},
+		},
+
+		{
+			format: `{{.x}}`,
+			deps:   formatDeps{capture: true},
+		},
+		{
+			format: `{{.Filename}}:{{.Line}}: {{.foo}}`,
+			deps:   formatDeps{capture: true},
+		},
+		{
+			format: `{{if .x}}hit{{else}}miss{{end}}`,
+			deps:   formatDeps{capture: true},
+		},
+	}
+
+	for _, test := range tests {
+		have := inspectFormatDeps(test.format)
+		want := test.deps
+		if have.capture != want.capture {
+			t.Errorf("inspect `%s`: capture=%v (want %v)",
+				test.format, have.capture, want.capture)
+			continue
+		}
+	}
+}


### PR DESCRIPTION
This is less conservative approach as it doesn't make
all non-default patterns pay for the extra collected data.

If -format contains capture variable ref, named captures are
collected. Otherwise they're ignored.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>