### PR TITLE
cmd/phpgrep: fix filters

### DIFF
--- a/cmd/phpgrep/end2end_test.go
+++ b/cmd/phpgrep/end2end_test.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestEnd2End(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	phpgrepBin := filepath.Join(wd, "phpgrep.exe")
+
+	out, err := exec.Command("go", "build", "-race", "-o", phpgrepBin, ".").CombinedOutput()
+	if err != nil {
+		t.Fatalf("build phpgrep: %v: %s", err, out)
+	}
+
+	type patternTest struct {
+		pattern string
+		filters []string
+		matches []string
+	}
+	tests := []struct {
+		name  string
+		tests []patternTest
+	}{
+		{
+			name: "filter",
+			tests: []patternTest{
+				// Test '=' for strings.
+				{
+					pattern: `define($name, $_)`,
+					filters: []string{`name="FOO"`},
+					matches: []string{`file.php:3: define("FOO", 1)`},
+				},
+				{
+					pattern: `define($name, $_)`,
+					filters: []string{`name='FOO'`},
+					matches: []string{`file.php:4: define('FOO', 2)`},
+				},
+				{
+					pattern: `define($name, $_)`,
+					filters: []string{`name='FOO','BAR'`},
+					matches: []string{
+						`file.php:4: define('FOO', 2)`,
+						`file.php:5: define('BAR', 3)`,
+					},
+				},
+
+				// Test `~` for strings.
+				{
+					pattern: `define($name, $_)`,
+					filters: []string{`name~"FOO"`},
+					matches: []string{`file.php:3: define("FOO", 1)`},
+				},
+				{
+					pattern: `define($name, $_)`,
+					filters: []string{`name~^"FOO"$`},
+					matches: []string{`file.php:3: define("FOO", 1)`},
+				},
+				{
+					pattern: `define($name, $_)`,
+					filters: []string{`name~^."FOO"$`},
+				},
+				{
+					pattern: `define($name, $_)`,
+					filters: []string{`name~^.."FOO".$`},
+				},
+
+				// Test '=' for ints.
+				{
+					pattern: `define($_, $v)`,
+					filters: []string{`v=2`},
+					matches: []string{
+						`file.php:4: define('FOO', 2)`,
+					},
+				},
+				{
+					pattern: `define($_, $v)`,
+					filters: []string{`v=1,2`},
+					matches: []string{
+						`file.php:3: define("FOO", 1)`,
+						`file.php:4: define('FOO', 2)`,
+					},
+				},
+
+				// Test '!=' for ints.
+				{
+					pattern: `define($_, $v)`,
+					filters: []string{`v!=2`},
+					matches: []string{
+						`file.php:3: define("FOO", 1)`,
+						`file.php:5: define('BAR', 3)`,
+					},
+				},
+				{
+					pattern: `define($_, $v)`,
+					filters: []string{`v!=3,2`},
+					matches: []string{
+						`file.php:3: define("FOO", 1)`,
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		testName := test.name
+		patternTests := test.tests
+		t.Run(test.name, func(t *testing.T) {
+			target := filepath.Join("testdata", testName)
+			if err := os.Chdir(target); err != nil {
+				t.Fatalf("chdir to test: %v", err)
+			}
+
+			for _, test := range patternTests {
+				phpgrepArgs := []string{".", test.pattern}
+				phpgrepArgs = append(phpgrepArgs, test.filters...)
+				out, err := exec.Command(phpgrepBin, phpgrepArgs...).CombinedOutput()
+				if err != nil {
+					if getExitCode(err) == 1 && len(test.matches) == 0 {
+						// OK: exit code 1 means "no matches".
+						return
+					}
+					t.Fatalf("run phpgrep: %v: %s", err, out)
+				}
+				have := strings.Split(strings.TrimSpace(string(out)), "\n")
+				want := test.matches
+				if diff := cmp.Diff(want, have); diff != "" {
+					t.Errorf("output mismatch (+have -want):\n%s", diff)
+				}
+			}
+
+			if err := os.Chdir(wd); err != nil {
+				t.Fatalf("chdir back: %v", err)
+			}
+		})
+	}
+}
+
+func getExitCode(err error) int {
+	if exiterr, ok := err.(*exec.ExitError); ok {
+		if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
+			return status.ExitStatus()
+		}
+	}
+	return -1
+}

--- a/cmd/phpgrep/testdata/filter/file.php
+++ b/cmd/phpgrep/testdata/filter/file.php
@@ -1,0 +1,5 @@
+<?php
+
+define("FOO", 1);
+define('FOO', 2);
+define('BAR', 3);

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/VKCOM/noverify v0.2.1-0.20200911093313-1002a2421df9
+	github.com/google/go-cmp v0.4.1
 	github.com/karrick/godirwalk v1.16.1 // indirect
 	github.com/quasilyte/go-consistent v0.0.0-20200404105227-766526bf1e96 // indirect
 	github.com/quasilyte/regex/syntax v0.0.0-20200805063351-8f842688393c // indirect

--- a/go.sum
+++ b/go.sum
@@ -54,4 +54,5 @@ golang.org/x/tools v0.0.0-20200329025819-fd4102a86c65 h1:1KSbntBked74wYsKq0jzXYy
 golang.org/x/tools v0.0.0-20200329025819-fd4102a86c65/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/phpgrep/worker.go
+++ b/internal/phpgrep/worker.go
@@ -80,7 +80,7 @@ func (w *worker) acceptMatch(m phpgrep.MatchData) bool {
 			continue
 		}
 		pos := ir.GetPosition(capture.Node)
-		buf := w.data[pos.StartPos-1 : pos.EndPos]
+		buf := w.data[pos.StartPos:pos.EndPos]
 		for _, filter := range filterList {
 			if !filter(buf) {
 				return false


### PR DESCRIPTION
At some point we updated php-parser.
A side effect of that is that there is no need to
subtract 1 from the start pos to get the [begin,end] slice.
We did subtract 1 and as a result text that was forwarded
to the filters always had 1 extra byte from the beginning.

This commit also adds a way to test a phpgrep binary (e2e test).

Updates #5

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>