### PR TITLE
do case-insensitive search by default

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/quasilyte/phpgrep
 go 1.15
 
 require (
-	github.com/VKCOM/noverify v0.2.1-0.20200911093313-1002a2421df9
+	github.com/VKCOM/noverify v0.2.1-0.20201022133834-e65df5cb935d
 	github.com/google/go-cmp v0.4.1
 	github.com/karrick/godirwalk v1.16.1 // indirect
 	github.com/quasilyte/go-consistent v0.0.0-20200404105227-766526bf1e96 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/VKCOM/noverify v0.2.1-0.20200903150659-a0b12e6eada2 h1:Cw0eKXsSP1lHV5
 github.com/VKCOM/noverify v0.2.1-0.20200903150659-a0b12e6eada2/go.mod h1:+OXCx6K3T1w8sUwIqMs5gviMIKNznkWAjklpAtjgV6c=
 github.com/VKCOM/noverify v0.2.1-0.20200911093313-1002a2421df9 h1:YXzY+6C/Rm55lqZy73avuTjcXgumx/Mhm8yd6MGgz14=
 github.com/VKCOM/noverify v0.2.1-0.20200911093313-1002a2421df9/go.mod h1:+OXCx6K3T1w8sUwIqMs5gviMIKNznkWAjklpAtjgV6c=
+github.com/VKCOM/noverify v0.2.1-0.20201022133834-e65df5cb935d h1:hV2ZFZzuTt8qvjX+G/BYq4ogS2gN+EraqcO8efmtBeY=
+github.com/VKCOM/noverify v0.2.1-0.20201022133834-e65df5cb935d/go.mod h1:+OXCx6K3T1w8sUwIqMs5gviMIKNznkWAjklpAtjgV6c=
 github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/go-toolsmith/astcast v1.0.0 h1:JojxlmI6STnFVG9yOImLeGREv8W2ocNUM+iOhR6jE7g=

--- a/internal/phpgrep/main.go
+++ b/internal/phpgrep/main.go
@@ -16,9 +16,10 @@ const (
 const defaultFormat = `{{.Filename}}:{{.Line}}: {{.Match}}`
 
 type arguments struct {
-	verbose   bool
-	multiline bool
-	abs       bool
+	verbose       bool
+	multiline     bool
+	abs           bool
+	caseSensitive bool
 
 	limit uint
 
@@ -119,6 +120,8 @@ Supported command-line flags:
 		`verbose mode: turn on additional debug logging`)
 	flag.BoolVar(&args.multiline, "m", false,
 		`multiline mode: print matches without escaping newlines to \n`)
+	flag.BoolVar(&args.caseSensitive, "case-sensitive", false,
+		`do a strict case matching, so F() and f() are considered to be distinct`)
 	flag.BoolVar(&args.abs, "abs", false,
 		`print absolute filenames in the output`)
 	flag.UintVar(&args.limit, "limit", 1000,

--- a/internal/phpgrep/program.go
+++ b/internal/phpgrep/program.go
@@ -120,6 +120,8 @@ func (p *program) compileFilters() error {
 
 func (p *program) compilePattern() error {
 	var c phpgrep.Compiler
+	c.CaseSensitive = p.args.caseSensitive
+
 	m, err := c.Compile([]byte(p.args.pattern))
 	if err != nil {
 		return err


### PR DESCRIPTION
If case sensitivity should be strict, -case-sensitive flag
can be used to match spellings literally.

Note that case insensitive mode only applies to things that
are insensitive in PHP as well: function and class names, etc.

Suppose we have this PHP code (test.php):

	a::f()
	a::F()

New phpgrep behavior:

	$ phpgrep test.php 'a::f()'
	finds both a::F() and a::f()

	$ phpgrep -case-sensitive test.php 'a::f()'
	finds only a::f()

Refs #57

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>