### PR TITLE
fix errors printing in "update" progress mode

### DIFF
--- a/internal/phpgrep/main.go
+++ b/internal/phpgrep/main.go
@@ -190,6 +190,9 @@ Supported command-line flags:
 	if len(argv) > 2 {
 		args.filters = argv[2:]
 	}
+	if args.verbose {
+		args.progressMode = "append"
+	}
 
 	if args.verbose {
 		log.Printf("debug: targets: %s", args.targets)

--- a/internal/phpgrep/worker.go
+++ b/internal/phpgrep/worker.go
@@ -25,6 +25,8 @@ type worker struct {
 	data     []byte
 	filename string
 	n        int
+
+	errors []string
 }
 
 func (w *worker) grepFile(filename string) (int, error) {


### PR DESCRIPTION
If --progress is set to "update", don't print the errors right
away, wait until we parse all files.

This helps to avoid the cluttered output.